### PR TITLE
Add `adjacentIterator` and fix `bfsIterator`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ for (n of node.bfsIterator()) {
 // Funnel
 ```
 
+### adjacentIterator()
+
+Returns an iterator that yields each adjacent outbound node. There is no guarantee
+about the order in which they are yielded.
+
+Example:
+
+```js
+// for a graph
+//  TreeMerger
+//    |- Babel_1
+//    |--|- Funnel
+//    |- Babel_2
+for (n of node.childIterator()) {
+  console.log(n.label.name);
+}
+// prints
+//
+// Babel_1
+// Babel_2
+```
+
 ### statsIterator()
 
 Returns an iterator that yields `[name, value]` pairs of stat names and values.

--- a/src/node.js
+++ b/src/node.js
@@ -31,15 +31,20 @@ export default class Node {
   }
 
   *bfsIterator(until=(x => false)) {
-    for (let child of this._children) {
-      if (until && until(child)) {
-        continue;
+    let queue = [this];
+
+    while (queue.length > 0) {
+      let node = queue.shift();
+      yield node;
+
+      for (let child of node.adjacentIterator()) {
+        if (until && until(child)) {
+          continue;
+        }
+
+        queue.push(child);
       }
-
-      yield* child.bfsIterator(until);
     }
-
-    yield this;
   }
 
   *adjacentIterator() {

--- a/src/node.js
+++ b/src/node.js
@@ -42,6 +42,12 @@ export default class Node {
     yield this;
   }
 
+  *adjacentIterator() {
+    for (let child of this._children) {
+      yield child;
+    }
+  }
+
   *ancestorsIterator() {
     if (this._parent) {
       yield this._parent;

--- a/tests/shared.js
+++ b/tests/shared.js
@@ -77,8 +77,20 @@ describe('heimdalljs-graph-shared', function() {
       for (let node of tree.bfsIterator()) {
         names.push(node.label.name);
       }
-      expect(names, 'post order').to.eql([
-        'd', 'a', 'h', 'f', 'z', 'k', 'j'
+      expect(names).to.eql([
+        'j', 'f', 'k', 'a', 'h', 'z', 'd'
+      ]);
+    });
+
+    it('allows specifying `until`', function() {
+      let tree = loadFromNode(node);
+
+      let names = [];
+      for (let node of tree.bfsIterator(n => n.label.name === 'a')) {
+        names.push(node.label.name);
+      }
+      expect(names).to.eql([
+        'j', 'f', 'k', 'h', 'z'
       ]);
     });
   });

--- a/tests/shared.js
+++ b/tests/shared.js
@@ -16,28 +16,33 @@ describe('heimdalljs-graph-shared', function() {
 
   beforeEach( function() {
     let heimdall = new Heimdall();
-
-    // a
-    // ├── b1
-    // │   └── c1
-    // └── b2
-    //     ├── c2
-    //     └── c3
     heimdall.registerMonitor('mystats', StatsSchema);
+
+    /*
+          tree
+          ----
+           j    <-- root
+         /   \
+        f      k
+      /   \      \
+     a     h      z
+      \
+       d
+    */
+
+    let j = heimdall.start('j');
+    let f = heimdall.start('f');
     let a = heimdall.start('a');
-    let b1 = heimdall.start({ name: 'b1', broccoliNode: true });
-    let c1 = heimdall.start('c1');
-    heimdall.statsFor('mystats').x = 3;
-    heimdall.statsFor('mystats').y = 4;
-    c1.stop();
-    b1.stop();
-    let b2 = heimdall.start('b2');
-    let c2 = heimdall.start({ name: 'c2', broccoliNode: true });
-    c2.stop();
-    let c3 = heimdall.start('c3');
-    c3.stop();
-    b2.stop();
+    let d = heimdall.start('d');
+    d.stop();
     a.stop();
+    let h = heimdall.start('h');
+    h.stop();
+    f.stop();
+    let k = heimdall.start('k');
+    let z = heimdall.start('z');
+    z.stop();
+    k.stop();
 
     node = heimdall.root._children[0];
   });
@@ -58,8 +63,8 @@ describe('heimdalljs-graph-shared', function() {
       for (let node of tree.dfsIterator()) {
         names.push(node.label.name);
       }
-      expect(names, 'pre order').to.eql([
-        'a', 'b1', 'c1', 'b2', 'c2', 'c3'
+      expect(names, 'depth first, pre order').to.eql([
+        'j','f','a','d','h','k','z'
       ]);
     });
   });
@@ -73,7 +78,7 @@ describe('heimdalljs-graph-shared', function() {
         names.push(node.label.name);
       }
       expect(names, 'post order').to.eql([
-        'c1', 'b1', 'c2', 'c3', 'b2', 'a'
+        'd', 'a', 'h', 'f', 'z', 'k', 'j'
       ]);
     });
   });
@@ -82,20 +87,20 @@ describe('heimdalljs-graph-shared', function() {
     it('works', function() {
       let tree = loadFromNode(node);
 
-      let c2 = null;
+      let d = null;
       for (let node of tree.dfsIterator()) {
-        if (node.label.name === 'c2') {
-          c2 = node;
+        if (node.label.name === 'd') {
+          d = node;
           break;
         }
       }
 
       let names = [];
-      for (let node of c2.ancestorsIterator()) {
+      for (let node of d.ancestorsIterator()) {
         names.push(node.label.name);
       }
       expect(names).to.eql([
-        'b2', 'a'
+        'a', 'f', 'j'
       ]);
     });
   });
@@ -124,8 +129,8 @@ describe('heimdalljs-graph-shared', function() {
         names.push(node.label.name);
       }
 
-      expect(names, 'pre order').to.eql([
-        'a', 'b1', 'c1', 'b2', 'c2', 'c3'
+      expect(names, 'depth first, pre order').to.eql([
+        'j','f','a','d','h','k','z'
       ]);
     });
   });

--- a/tests/shared.js
+++ b/tests/shared.js
@@ -100,6 +100,21 @@ describe('heimdalljs-graph-shared', function() {
     });
   });
 
+  describe('adjacentIterator', function() {
+    it('works', function() {
+      let tree = loadFromNode(node);
+
+      let names = [];
+      for (let node of tree.adjacentIterator()) {
+        names.push(node.label.name);
+      }
+
+      expect(names, 'adjacent nodes').to.eql([
+        'f', 'k'
+      ]);
+    });
+  });
+
   describe('Symbol.iterator', function() {
     it('works', function() {
       let tree = loadFromNode(node);


### PR DESCRIPTION
* Add `Node.prototype.adjacentIterator`.
* Fix `bfsIterator` to actually be a breadth first search (I had previously renamed `posOrderIterator` to `bfsIterator` which was completely incorrect).
* Swap to a better tree diagram and deeper structure (to enable testing of `bfsIterator`).